### PR TITLE
Update D08-hes_apc.py

### DIFF
--- a/D08-hes_apc.py
+++ b/D08-hes_apc.py
@@ -278,7 +278,7 @@ hes_apc_cips_episodes = (
     .withColumn('previous_admidate', f.lag('admidate').over(window_p_spell_grouping))
     .withColumn('previous_epistart', f.lag('epistart').over(window_p_spell_grouping))
     .withColumn('previous_dismeth', f.lag('dismeth').over(window_p_spell_grouping))
-    .withColumn('previous_epiend', f.lag('dismeth').over(window_p_spell_grouping))
+    .withColumn('previous_epiend', f.lag('epiend').over(window_p_spell_grouping))
 )
 
 # An episode is considered to be part of the same provider spell as the previous 


### PR DESCRIPTION
Problem
- `previous_epiend` is currently defined as `lag('dismeth')` instead of `lag('epiend')`.

Change
- replace `lag('dismeth')` with `lag('epiend')` when creating previous_epiend
